### PR TITLE
wine pckgs versions, old build_wine.sh, osx pyinstaller version

### DIFF
--- a/Dockerfile-wine
+++ b/Dockerfile-wine
@@ -40,7 +40,15 @@ RUN rm -rf /tmp/.wine-* ; wineboot --update ; xvfb-run -a wine nsis.exe /S
 
 RUN rm -rf /tmp/.wine-* ; wineboot --update ; wine python -m ensurepip
 RUN wineboot --update ; wine python C:/Python27/Scripts/pip.exe install \
-    dnspython slowaes ecdsa requests six qrcode pbkdf2 protobuf jsonrpclib
+    dnspython==1.12.0 \
+    slowaes==0.1a1 \
+    ecdsa==0.13 \
+    requests==2.5.1 \
+    six==1.11.0 \
+    qrcode==5.1 \
+    pbkdf2==1.3 \
+    protobuf==2.6.1 \
+    jsonrpclib==0.1.7
 
 # so pyinstaller would find `google.protobuf`
 RUN touch /root/.wine/drive_c/Python27/Lib/site-packages/google/__init__.py

--- a/before_install-osx.sh
+++ b/before_install-osx.sh
@@ -11,4 +11,4 @@ git clone  https://github.com/trezor/cython-hidapi
 git clone https://github.com/akhavr/python-trezor
 (cd python-trezor/ ; sudo python setup.py build install bdist)
 
-sudo pip2 install pyinstaller
+sudo pip2 install pyinstaller==3.2.1

--- a/build_wine.sh
+++ b/build_wine.sh
@@ -2,7 +2,7 @@
 wineboot && sleep 5
 wineboot --update
 
-cp /root/.wine/drive_c/Python27/Lib/site-packages/pip/_vendor/requests/cacert.pem .
+cp /root/.wine/drive_c/Python27/Lib/site-packages/requests/cacert.pem .
 wine python "C:/PyInstaller/pyinstaller.py" -y "contrib/build-wine/deterministic.spec"
 cp /opt/electrum-dash/contrib/build-wine/electrum-dash.nsi /root/.wine/drive_c/
 cd /root/.wine/drive_c/electrum


### PR DESCRIPTION
Set wine packages versions to versions from requirements.txt

Get cacert.pem again from site-packages/requests/cacert.pem

Fix osx PyInstaller version to 3.2.1 as 3.3 fails to build.