### PR TITLE
Fix logic errors, add option, desription, mulitrepo config

### DIFF
--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -2,20 +2,41 @@
 # -*- coding: utf-8 -*-
 """Sign releases on github
 
-Settings is read from options, repo is read aslo from current dir
-'git remote -v' output, filtered by 'origin', then config file is read.
+Settings is read from options, then if repo not set, repo is read from
+current dire 'git remote -v' output, filtered by 'origin', then config
+file is read.
 
-If setting is set from option, then do not changes when 'git remote -v'
-is read or when config file is read. Config file options is set if no
-other means set it before.
+If setting is already set then it value does not changes.
 
-Config file can have one repo or multiple repos configs in "repos" list.
-If "default_repo" is set, then code try to read "repos" list and cycle
-through it to find suitable repo, or if no repo is set before, then
-"default_repo" is used to match.
+Config file can have one repo form or multiple repo form.
 
-One repo config can contain "repo", "keyid", "token", "count"
-and "sign_drafts" keys, which is correspond to program options.
+In one repo form config settings read from root JSON object.
+Keys are "repo", "keyid", "token", "count" and "sign_drafts",
+which is correspond to program options.
+
+Example:
+
+    {
+        "repo": "value"
+        ...
+    }
+
+In multiple repo form, if root "default_repo" key is set, then code
+try to read "repos" key as list and cycle through it to find suitable
+repo, or if no repo is set before, then "default_repo" is used to match.
+If match found, then that list object is used ad one repo form config.
+
+Example:
+
+    {
+        "default_repo": "value"
+        "repos": [
+            {
+                "repo": "value"
+                ...
+            }
+        ]
+    }
 """
 
 import os

--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -98,8 +98,14 @@ def check_github_repo(remote_name='origin'):
             repo = repo.split(':')[-1]
 
         if repo.startswith('http'):
+            if repo.endswith('/'):
+                repo = repo[:-1]
+
             repo = repo.split('/')
             repo = '/'.join(repo[-2:])
+
+        if repo.endswith('.git'):
+            repo = repo[:-4]
 
     return repo
 
@@ -146,7 +152,8 @@ class SignApp(object):
             print 'GITHUB_TOKEN environment var not set, exit'
             sys.exit(0)
 
-        self.keyid = self.keyid.split('/')[-1]
+        if self.keyid:
+            self.keyid = self.keyid.split('/')[-1]
 
         self.passphrase = None
         self.gpg = gnupg.GPG()

--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -248,6 +248,10 @@ class SignApp(object):
         releases.sort(compare_published_times)
         for r in releases[:self.count]:
             asset_names = [a['name'] for a in r['assets']]
+
+            if not asset_names:
+                continue
+
             asc_names = [a for a in asset_names if a.endswith('.asc')]
             other_names = [a for a in asset_names if not a.endswith('.asc')]
             need_to_sign = False

--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -1,5 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""Sign releases on github
+
+Settings is read from options, repo is read aslo from current dir
+'git remote -v' output, filtered by 'origin', then config file is read.
+
+If setting is set from option, then do not changes when 'git remote -v'
+is read or when config file is read. Config file options is set if no
+other means set it before.
+
+Config file can have one repo or multiple repos configs in "repos" list.
+If "default_repo" is set, then code try to read "repos" list and cycle
+through it to find suitable repo, or if no repo is set before, then
+"default_repo" is used to match.
+
+One repo config can contain "repo", "keyid", "token", "count"
+and "sign_drafts" keys, which is correspond to program options.
+"""
 
 import os
 import os.path
@@ -90,7 +107,6 @@ def check_github_repo(remote_name='origin'):
     except:
         remotes = []
     remotes = [r for r in remotes if remote_name in r]
-    remotes = [r for r in remotes if '(push)' in r]
     repo = remotes[0].split()[1] if len(remotes) > 0 else None
 
     if repo:
@@ -157,6 +173,8 @@ class SignApp(object):
             self.keyid = self.keyid or self.config.get('keyid', None)
             self.count = self.count or self.config.get('count', None) \
                          or SEARCH_COUNT
+            self.sign_drafts = self.sign_drafts \
+                         or self.config.get('sign_drafts', False)
 
         if not self.repo:
             print 'no repo found, exit'
@@ -269,7 +287,7 @@ class SignApp(object):
             is_prerelease = r.get('prerelease', False)
             created_at = r.get('created_at', '')
 
-            msg = 'Sign %s%s tagged: %s, created at: %s' % (
+            msg = 'Found %s%s tagged: %s, created at: %s' % (
                 'draft ' if is_draft else '',
                 'prerelease' if is_prerelease else 'release',
                 tag_name,

--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -169,8 +169,8 @@ class SignApp(object):
         self.count = kwargs.pop('count', None)
         self.dry_run = kwargs.pop('dry_run', None)
 
-        repo = check_github_repo()
-        self.repo = self.repo or repo
+        if not self.repo:
+            self.repo = check_github_repo()
 
         self.config = {}
         config_data = read_config()

--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -125,6 +125,7 @@ class SignApp(object):
     def __init__(self, **kwargs):
         """Get app settings from options, from curdir git, from config file"""
         ask_passphrase = kwargs.pop('ask_passphrase', None)
+        self.sign_drafts = kwargs.pop('sign_drafts', False)
         self.repo = kwargs.pop('repo', None)
         self.token = kwargs.pop('token', None)
         self.keyid = kwargs.pop('keyid', None)
@@ -237,7 +238,12 @@ class SignApp(object):
         """Search through last 'count' releases with assets without
         .asc counterparts or releases withouth SHA256SUMS.txt.asc
         """
+        print 'Sign releases on repo: %s' % self.repo
         releases = get_releases(self.repo)
+
+        if not self.sign_drafts:
+            releases = [r for r in releases if not r.get('draft', False)]
+
         # cycle through releases sorted by by publication date
         releases.sort(compare_published_times)
         for r in releases[:self.count]:
@@ -266,6 +272,8 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-c', '--count', type=int,
               help='Number of last releases to sign')
+@click.option('-d', '--sign-drafts', is_flag=True,
+              help='Sing draft releases')
 @click.option('-k', '--keyid',
               help='gnupg keyid')
 @click.option('-n', '--dry-run', is_flag=True,

--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -135,12 +135,28 @@ class SignApp(object):
         repo = check_github_repo()
         self.repo = self.repo or repo
 
-        self.config = read_config()
-        self.repo = self.repo or self.config.get('repo', None)
-        self.token = self.token or self.config.get('token', None)
-        self.keyid = self.keyid or self.config.get('keyid', None)
-        self.count = self.count or self.config.get('count', None) \
-                     or SEARCH_COUNT
+        self.config = {}
+        config_data = read_config()
+
+        default_repo = config_data.get('default_repo', None)
+        if default_repo:
+            if not self.repo:
+                self.repo = default_repo
+
+            for config in config_data.get('repos', []):
+                config_repo = config.get('repo', None)
+                if config_repo and config_repo == self.repo:
+                    self.config = config
+                    break
+        else:
+            self.config = config_data
+
+        if self.config:
+            self.repo = self.repo or self.config.get('repo', None)
+            self.token = self.token or self.config.get('token', None)
+            self.keyid = self.keyid or self.config.get('keyid', None)
+            self.count = self.count or self.config.get('count', None) \
+                         or SEARCH_COUNT
 
         if not self.repo:
             print 'no repo found, exit'

--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -36,17 +36,18 @@ SHA_FNAME = 'SHA256SUMS.txt'
 def compare_published_times(a, b):
     """Releases list sorting comparsion function"""
 
-    a_published = a['published_at']
-    b_published = b['published_at']
+    a = a['published_at']
+    b = b['published_at']
 
-    if not a_published:
+    if not a and not b:
+        return 0
+    elif not a:
         return -1
-
-    if not b_published:
+    elif not b:
         return 1
 
-    a = dateutil.parser.parse(a_published)
-    b = dateutil.parser.parse(b_published)
+    a = dateutil.parser.parse(a)
+    b = dateutil.parser.parse(b)
 
     if a > b:
         return -1


### PR DESCRIPTION
Fixed logic errors in:
 - fix compare_published_times logic
 - fix check_github_repo logic, do not split keyid if not set
 - skip release if no assets

Added `-d` option, to not skip draft releases.
Previous version do not skip, this skip if no option or no config file key.

Addeв small desription, and more diagnostic output.